### PR TITLE
Remove tray_icon from wallpaper changer API

### DIFF
--- a/src/framechanger/app.py
+++ b/src/framechanger/app.py
@@ -696,7 +696,7 @@ class MainWindow(QMainWindow):
 
     def change_wallpaper(self):
         """Change the wallpaper to a random image from the favorites list."""
-        result, title = change_wallpaper(self.tray_icon)
+        result, title = change_wallpaper()
         if result == 0:
             self.show_custom_notification("Wallpaper Changed", f"Wallpaper changed to {title}", 3000)
         else:
@@ -706,7 +706,7 @@ class MainWindow(QMainWindow):
         """Set a specific wallpaper based on the selected index."""
         selected_item = index.data()
         title, media_type = selected_item.split(' | ')
-        result, title_name = set_specific_wallpaper(title, media_type, self.tray_icon)
+        result, title_name = set_specific_wallpaper(title, media_type)
         if result == 0:
             self.show_custom_notification("Wallpaper Changed", f"Wallpaper changed to {title_name}", 3000)
         else:

--- a/src/framechanger/wallpaper_changer.py
+++ b/src/framechanger/wallpaper_changer.py
@@ -191,7 +191,7 @@ def set_wallpaper(image_path):
         logging.error(f"Error setting wallpaper: {e}")
         return False
 
-def change_wallpaper(tray_icon):
+def change_wallpaper():
     """Download a random wallpaper and set it as the background."""
     api_key = get_api_key()
     if not api_key:
@@ -204,7 +204,7 @@ def change_wallpaper(tray_icon):
     logging.error("Failed to set the wallpaper.")
     return 1, ""
 
-def set_specific_wallpaper(title_name, media_type, tray_icon):
+def set_specific_wallpaper(title_name, media_type):
     """Set the wallpaper to a specific movie or TV show."""
     api_key = get_api_key()
     if not api_key:
@@ -269,4 +269,4 @@ if __name__ == '__main__':
     app = QApplication(sys.argv)
     api_key = get_api_key()
     if api_key:
-        set_specific_wallpaper("Example Title", "movie", None)
+        set_specific_wallpaper("Example Title", "movie")


### PR DESCRIPTION
## Summary
- simplify wallpaper_changer API by removing `tray_icon` argument
- adjust app to call the updated functions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426a376704832584fbef8dc6eb0223