### PR TITLE
Store user data under config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ FrameChanger supports Windows, macOS and most Linux desktops. Wallpaper changes 
 
 ## Configuration
 
-- **Database:** Uses SQLite to store favorites.
-- **Settings:** Configuration stored in `settings.json`. Set your TMDB API key with the `TMDB_API_KEY` environment variable or enter it on first run.
+- **Database:** Uses SQLite to store favorites in `~/.framechanger/titles.db`.
+- **Settings:** Configuration stored in `~/.framechanger/settings.json`. Set your TMDB API key with the `TMDB_API_KEY` environment variable or enter it on first run.
 
 ## Credits
 

--- a/src/framechanger/app.py
+++ b/src/framechanger/app.py
@@ -43,9 +43,10 @@ from framechanger.wallpaper_changer import (
     get_api_key,
 )
 
-# Constants for database and settings file
-DATABASE_NAME = 'titles.db'
-SETTINGS_FILE = 'auto_changer_settings.json'
+from framechanger.paths import DATABASE_PATH
+
+# Constants
+DATABASE_NAME = str(DATABASE_PATH)
 
 # Set up logging
 LOG_FILE = os.path.join(os.path.expanduser("~"), "framechanger.log")

--- a/src/framechanger/paths.py
+++ b/src/framechanger/paths.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import os
+
+# Base directory for app data
+APP_DIR = Path(os.getenv("FRAMECHANGER_APP_DIR", Path.home() / ".framechanger"))
+APP_DIR.mkdir(parents=True, exist_ok=True)
+
+# Data files stored under APP_DIR
+DATABASE_PATH = APP_DIR / "titles.db"
+SETTINGS_PATH = APP_DIR / "settings.json"

--- a/src/framechanger/wallpaper_changer.py
+++ b/src/framechanger/wallpaper_changer.py
@@ -14,6 +14,8 @@ from PyQt5.QtCore import Qt
 import sys
 import logging
 
+from .paths import APP_DIR, DATABASE_PATH, SETTINGS_PATH
+
 LOG_FILE = os.path.join(os.path.expanduser("~"), "framechanger.log")
 logging.basicConfig(
     level=logging.INFO,
@@ -26,9 +28,8 @@ logging.basicConfig(
 
 API_KEY_ENV_VAR = "TMDB_API_KEY"
 
-script_dir = os.path.dirname(os.path.abspath(sys.executable if getattr(sys, 'frozen', False) else __file__))
-image_dir = os.path.join(script_dir, 'MovieStillsWallpaperChanger')
-settings_file = os.path.join(script_dir, 'settings.json')
+image_dir = os.path.join(APP_DIR, 'MovieStillsWallpaperChanger')
+settings_file = str(SETTINGS_PATH)
 
 if not os.path.exists(image_dir):
     os.mkdir(image_dir)
@@ -140,7 +141,7 @@ def download_wallpaper(title_name, media_type, api_key):
 
 def download_random_image(api_key):
     """Get a random title from the database and download its wallpaper."""
-    conn = sqlite3.connect('titles.db')
+    conn = sqlite3.connect(str(DATABASE_PATH))
     c = conn.cursor()
     c.execute("SELECT * FROM titles")
     rows = c.fetchall()
@@ -245,7 +246,7 @@ def initialize_database():
         ("Fleabag", "tv")
     ]
 
-    conn = sqlite3.connect('titles.db')
+    conn = sqlite3.connect(str(DATABASE_PATH))
     c = conn.cursor()
     
     # Create the titles table if it doesn't exist

--- a/tests/test_wallpaper_changer.py
+++ b/tests/test_wallpaper_changer.py
@@ -3,13 +3,17 @@ import sqlite3
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 from framechanger import wallpaper_changer as wc
+from framechanger import paths
 
 
 def test_initialize_database(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(paths, 'APP_DIR', tmp_path, raising=False)
+    monkeypatch.setattr(paths, 'DATABASE_PATH', tmp_path / 'titles.db', raising=False)
+    monkeypatch.setattr(wc, 'APP_DIR', tmp_path, raising=False)
+    monkeypatch.setattr(wc, 'DATABASE_PATH', tmp_path / 'titles.db', raising=False)
     wc.initialize_database()
-    assert os.path.exists('titles.db')
-    conn = sqlite3.connect('titles.db')
+    assert (tmp_path / 'titles.db').exists()
+    conn = sqlite3.connect(tmp_path / 'titles.db')
     c = conn.cursor()
     c.execute('SELECT COUNT(*) FROM titles')
     count = c.fetchone()[0]
@@ -18,7 +22,9 @@ def test_initialize_database(tmp_path, monkeypatch):
 
 
 def test_load_settings(tmp_path, monkeypatch):
-    settings_file = tmp_path / 'settings.json'
-    monkeypatch.setattr(wc, 'settings_file', str(settings_file))
+    monkeypatch.setattr(paths, 'APP_DIR', tmp_path, raising=False)
+    monkeypatch.setattr(paths, 'SETTINGS_PATH', tmp_path / 'settings.json', raising=False)
+    monkeypatch.setattr(wc, 'APP_DIR', tmp_path, raising=False)
+    monkeypatch.setattr(wc, 'settings_file', str(tmp_path / 'settings.json'), raising=False)
     settings = wc.load_settings()
     assert 'api_key' in settings


### PR DESCRIPTION
## Summary
- centralize data paths under `paths.APP_DIR`
- store `titles.db` and `settings.json` in the app directory
- update modules and tests to use new paths
- mention new locations in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426a4680208325883668107661affa